### PR TITLE
Introduce patch to remove data_files from setup.py

### DIFF
--- a/recipe/fix_setup.patch
+++ b/recipe/fix_setup.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index 4dbbae4..38e1dc3 100644
+--- a/setup.py
++++ b/setup.py
+@@ -45,7 +45,6 @@ setup(
+     license='BSD',
+     url='https://gitlab.com/alelec/pip-system-certs',
+     packages=['pip_system_certs'],
+-    data_files=[(site_packages, ['pip_system_certs.pth'])],
+     install_requires=['wrapt>=1.10.4', 'setuptools_scm'],
+     zip_safe=False,
+     cmdclass={"install": InstallCheck, "develop": DevelopCheck},

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,11 +8,13 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pip_system_certs-{{ version }}.tar.gz
   sha256: fe9ea4e25f4c4977cf5b38d7fd7fe192fbfe7cd5e53edbf5b4b37ae3fadbd5d6
+  patches:
+    - fix_setup.patch
 
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:


### PR DESCRIPTION
It seems that this line created an invalid package which contained the
exact location to the pth-file despite the pth-file being installed
correctly from the copy part of InstallCheck.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
