### PR TITLE
Fix version metadata mismatch by removing git-versioner dependency and using static version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,17 +9,18 @@ package:
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/pip_system_certs-{{ version }}.tar.gz
   sha256: 19c8bf9957bcce7d69c4dbc2d0b2ef13de1984d53f50a59012e6dbbad0af67c6
+  patches:
+    - static-version.patch
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python >={{ python_min }}
     - pip
-    - git-versioner
     - wheel
     - setuptools >=61
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   host:
-    - python >={{ python_min }}
+    - python {{ python_min }}
     - pip
     - wheel
     - setuptools >=61

--- a/recipe/static-version.patch
+++ b/recipe/static-version.patch
@@ -1,0 +1,27 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["setuptools>=61.0", "wheel", "git-versioner"]
++requires = ["setuptools>=61.0", "wheel"]
+ build-backend = "setuptools.build_meta:__legacy__"
+
+ [project]
+@@ -26,7 +26,7 @@
+     "pip>=24.2"
+ ]
+ requires-python = ">=3.10"
+-dynamic = ["version"]
++version = "5.3"
+
+ [project.urls]
+ Homepage = "https://gitlab.com/alelec/pip-system-certs"
+@@ -37,8 +37,3 @@
+ zip-safe = false
+ packages = ["pip_system_certs"]
+
+-[tool.git-versioner]
+-gitlab = true
+-desc = true
+-snapshot = true
+-


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
## Description
Fixes the version metadata issue where the conda-forge package was showing `0.1+g7d58285.dirty` instead of the correct version `5.3`. (#14)

## Changes
- Removed `git-versioner` from host requirements
- Added patch file to use static version instead of dynamic versioning from git
- Added `--no-build-isolation` flag to build script to override the dependency on `git-versioner` from the upstream repo

## Issue
The package uses `git-versioner` for dynamic versioning, which fails when building from PyPI tarballs (no git history). This caused the package metadata to show an incorrect version.

## Testing
- [x] Built locally and verified version is correct (`5.3`)
**conda-forge installation:**
```bash
pip show pip-system-certs                                                         (test) 
Name: pip_system_certs
Version: 0.1+g7d58285.dirty
Summary: Automatically configures Python to use system certificates via truststore
Home-page: https://gitlab.com/alelec/pip-system-certs
Author: 
Author-email: Andrew Leech <andrew@alelec.net>
License-Expression: BSD-3-Clause
Location: /conda/envs/test/lib/python3.12/site-packages
Requires: pip
Required-by:
```
**Local build with the fix:**
```bash
pip show pip-system-certs                                                         (test) 
Name: pip_system_certs
Version: 5.3
Summary: Automatically configures Python to use system certificates via truststore
Home-page: https://gitlab.com/alelec/pip-system-certs
Author: 
Author-email: Andrew Leech <andrew@alelec.net>
License-Expression: BSD-3-Clause
Location: /conda/envs/test/lib/python3.12/site-packages
Requires: pip
Required-by: 
```
- [x] Tested with `pip show pip-system-certs`
- [x] Tested with `python -c "import importlib.metadata; print(importlib.metadata.version('pip-syst
em-certs'))"`

## related issues
closes #14 

# Disclaimer
This is my first PR in the conda-realm so If I made any mistakes or things could be optimized, please let me know. I am here to learn :)